### PR TITLE
result screen crashed

### DIFF
--- a/app/src/main/java/com/example/foreverfreedictionary/data/cloud/DictionaryDataCloud.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/cloud/DictionaryDataCloud.kt
@@ -39,8 +39,8 @@ class DictionaryDataCloud : DictionaryDataDs {
         }
         val ipaBr = document.selectFirst("span.PRON").text()
         val ipaAme = document.selectFirst("span.AMEVARPRON")?.text()
-        val soundBr = document.selectFirst("span.speaker.amefile").attr("data-src-mp3")
-        val soundAme = document.selectFirst("span.speaker.brefile").attr("data-src-mp3")
+        val soundBr = document.selectFirst("span.speaker.amefile")?.attr("data-src-mp3")
+        val soundAme = document.selectFirst("span.speaker.brefile")?.attr("data-src-mp3")
         val dictionary = Dictionary(query, content, soundBr, soundAme, ipaBr, ipaAme, url)
         return Resource.success(dictionary)
     }

--- a/app/src/main/java/com/example/foreverfreedictionary/data/cloud/model/Models.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/cloud/model/Models.kt
@@ -7,8 +7,8 @@ data class SearchText(@SerializedName("searchtext")val suggestion: String)
 data class Dictionary(
     val word: String,
     val content: String,
-    val soundBr: String,
-    val soundAme: String,
+    val soundBr: String?,
+    val soundAme: String?,
     val ipaBr: String,
     /**american accent*/
     val ipaAme: String? = null,

--- a/app/src/main/java/com/example/foreverfreedictionary/data/local/tables.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/local/tables.kt
@@ -36,9 +36,9 @@ data class TblDictionary(
     @field:SerializedName("content")
     val content: String,
     @field:SerializedName("sound_br")
-    val soundBr: String,
+    val soundBr: String?,
     @field:SerializedName("sound_ame")
-    val soundAme: String,
+    val soundAme: String?,
     @field:SerializedName("ipa_br")
     val ipaBr: String,
     @field:SerializedName("ipa_Ame")


### PR DESCRIPTION
- due to jsoup selections return null
- surround that block code by try-catch
- get redirected url returned from jsoup to determine which page was return.
- history table, dictionary table now use query as primary key instead of word.