### PR TITLE
result screen crashed

### DIFF
--- a/app/src/main/java/com/example/foreverfreedictionary/data/cloud/DictionaryDataCloud.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/cloud/DictionaryDataCloud.kt
@@ -2,49 +2,67 @@ package com.example.foreverfreedictionary.data.cloud
 
 import com.example.foreverfreedictionary.data.cloud.model.Dictionary
 import com.example.foreverfreedictionary.domain.datasource.DictionaryDataDs
+import com.example.foreverfreedictionary.util.CHECK_SPELL_URL
 import com.example.foreverfreedictionary.util.DICTIONARY_URL
-import com.example.foreverfreedictionary.util.DOMAIN
+import com.example.foreverfreedictionary.util.SEARCH_FORM_SUBMIT_DIRECTION_URL
 import com.example.foreverfreedictionary.vo.Resource
 import org.jsoup.Jsoup
+import timber.log.Timber
 
 class DictionaryDataCloud : DictionaryDataDs {
-        override suspend fun queryDictionaryData(query: String): Resource<Dictionary> {
-        val url = if (query.contains('/') || query.contains('?')){
-                        DOMAIN + query
-                    }else if(query.contains(' ')){
-                        DICTIONARY_URL + query.replace(",", "").replace(" ", "-")
-                    }else {
-                        DICTIONARY_URL + query
-                    }
-        val document = Jsoup.connect(url).get()
-            val hasContent = document.selectFirst("div.entry_content") != null
+    override suspend fun queryDictionaryData(query: String): Resource<Dictionary> {
+        try {
+            val url =
+//            if (query.contains('/') || query.contains('?')){
+//                DOMAIN + query
+//            }else if(query.contains(' ')){//query example: "want for something"
+//                SEARCH_FORM_SUBMIT_DIRECTION_URL + query.replace(",", "").replace(" ", "-")
+//            }else {
+                SEARCH_FORM_SUBMIT_DIRECTION_URL + query
+//            }
+            val response = Jsoup.connect(url).followRedirects(true).execute()
+            val document = response.parse()
+            val location = response.url().toExternalForm()
+            val isDictionaryPage = location.startsWith(DICTIONARY_URL)
+            val isCheckSpellPage = location.startsWith(CHECK_SPELL_URL)
 
-        val content = if (document.selectFirst("div.page_content") !=null || hasContent){
-            //remove unnecessary elements
-            document.select(".header").remove()
-            document.select("#ad_leftslot_container").remove()
-            document.select(".responsive_cell2").remove()
-            document.select(".footer").remove()
-
-            if (hasContent){
+            return if (isDictionaryPage || isCheckSpellPage) {
+                //remove unnecessary elements
+                document.select(".header").remove()
+                document.select("#ad_leftslot_container").remove()
+                document.select(".responsive_cell2").remove()
+                document.select(".footer").remove()
                 document.select("link[href^=https://d27ucmmhxk51xv.cloudfront.net/external/fonts/font-awesome/4.2.0/css/font-awesome.min.css]")
-                    .forEach { cssElement ->
+                    ?.forEach { cssElement ->
                         cssElement.attr("href", "css/font-awesome.min.css")
                     }
-            }
 
-            document.html()
-        }else{
-            "Oops something went wrong"
+
+                val entryContent = document.selectFirst("div.entry_content")
+                val content = document.html()
+                val dictionary = if (isDictionaryPage) {
+                    val word = entryContent.selectFirst(".pagetitle").text()
+                    val ipaBr = entryContent.selectFirst("span.PRON")?.text()
+                    var ipaAme = entryContent.selectFirst("span.AMEVARPRON")?.text()
+                    val soundBr =
+                        entryContent.selectFirst("span.speaker.amefile")?.attr("data-src-mp3")
+                    val soundAme =
+                        entryContent.selectFirst("span.speaker.brefile")?.attr("data-src-mp3")
+                    if (ipaAme?.startsWith("$") == true) {
+                        ipaAme = ipaAme.substringAfter("$")
+                    }
+                    Dictionary(query, word, content, soundBr, soundAme, ipaBr, ipaAme, url)
+                } else {//the check spell page
+                    Dictionary(query, query, content, null, null, null, null, location)
+                }
+
+                Resource.success(dictionary)
+            } else {
+                Resource.error("Oops something went wrong")
+            }
+        }catch (e: Exception){
+            Timber.e(e)
+            return Resource.error("Oops something went wrong")
         }
-        val ipaBr = document.selectFirst("span.PRON").text()
-        var ipaAme = document.selectFirst("span.AMEVARPRON")?.text()
-        val soundBr = document.selectFirst("span.speaker.amefile")?.attr("data-src-mp3")
-        val soundAme = document.selectFirst("span.speaker.brefile")?.attr("data-src-mp3")
-        if (ipaAme?.startsWith("$") == true){
-            ipaAme = ipaAme.substringAfter("$")
-        }
-        val dictionary = Dictionary(query, content, soundBr, soundAme, ipaBr, ipaAme, url)
-        return Resource.success(dictionary)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/data/cloud/model/Models.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/cloud/model/Models.kt
@@ -5,11 +5,12 @@ import com.google.gson.annotations.SerializedName
 data class AutoCompletionResponse(@SerializedName("results") val results: List<SearchText>)
 data class SearchText(@SerializedName("searchtext")val suggestion: String)
 data class Dictionary(
+    val query: String,
     val word: String,
     val content: String,
     val soundBr: String?,
     val soundAme: String?,
-    val ipaBr: String,
+    val ipaBr: String?,
     /**american accent*/
     val ipaAme: String? = null,
     val url: String

--- a/app/src/main/java/com/example/foreverfreedictionary/data/local/room/DictionaryDao.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/local/room/DictionaryDao.kt
@@ -9,8 +9,8 @@ import com.example.foreverfreedictionary.data.local.TblDictionary
 
 @Dao
 interface DictionaryDao {
-    @Query("SELECT * FROM dictionary WHERE word = :word LIMIT 1")
-    fun getDictionary(word: String): LiveData<TblDictionary>
+    @Query("SELECT * FROM dictionary WHERE `query` = :query LIMIT 1")
+    fun getDictionary(query: String): LiveData<TblDictionary>
 
 //    @Query("SELECT * FROM sets WHERE themeId = :themeId ORDER BY year DESC")
 //    fun getPagedLegoSetsByTheme(themeId: Int): DataSource.Factory<Int, LegoSet>

--- a/app/src/main/java/com/example/foreverfreedictionary/data/local/tables.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/local/tables.kt
@@ -12,13 +12,15 @@ import java.sql.Date
     tableName = "history",
     foreignKeys = [ForeignKey(
         entity = TblDictionary::class,
-        parentColumns = arrayOf("word"),
-        childColumns = arrayOf("word"),
+        parentColumns = arrayOf("query"),
+        childColumns = arrayOf("query"),
         onDelete = CASCADE)
         ],
     indices = [Index("word")])
 data class TblHistory(
     @PrimaryKey
+    @field:SerializedName("query")
+    val query: String,
     @field:SerializedName("word")
     val word: String,
     @field:SerializedName("last_access")
@@ -28,9 +30,12 @@ data class TblHistory(
     }
 }
 
-@Entity(tableName = "dictionary")
+@Entity(tableName = "dictionary",
+    indices = [Index("word")])
 data class TblDictionary(
     @PrimaryKey
+    @field:SerializedName("query")
+    val query: String,
     @field:SerializedName("word")
     val word: String,
     @field:SerializedName("content")
@@ -40,7 +45,7 @@ data class TblDictionary(
     @field:SerializedName("sound_ame")
     val soundAme: String?,
     @field:SerializedName("ipa_br")
-    val ipaBr: String,
+    val ipaBr: String?,
     @field:SerializedName("ipa_Ame")
     val ipaAme: String?,
     @field:SerializedName("last_access")

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/mapper/DictionaryMapper.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/mapper/DictionaryMapper.kt
@@ -12,7 +12,7 @@ class DictionaryMapper {
      */
     fun toData(dictionary: DictionaryCloud): TblDictionary {
         return with(dictionary){
-            TblDictionary(word, content, soundBr, soundAme, ipaBr, ipaAme, Date(System.currentTimeMillis()))
+            TblDictionary(query, word, content, soundBr, soundAme, ipaBr, ipaAme, Date(System.currentTimeMillis()))
         }
     }
 
@@ -23,7 +23,7 @@ class DictionaryMapper {
         return when(resource.status){
             Status.LOADING -> {Resource.loading()}
             Status.ERROR -> {Resource.error(resource.message)}
-            Status.SUCCESS -> {Resource.success(resource.data!!.content)}
+            Status.SUCCESS -> {Resource.success(resource.data?.content)}
         }
     }
 

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/mapper/HistoryMapper.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/mapper/HistoryMapper.kt
@@ -1,11 +1,12 @@
 package com.example.foreverfreedictionary.domain.mapper
 
+import com.example.foreverfreedictionary.data.cloud.model.Dictionary
 import com.example.foreverfreedictionary.data.local.TblHistory
 import java.sql.Date
 import java.util.*
 
 class HistoryMapper {
-    fun toData(query: String): TblHistory {
-        return TblHistory(query, Date(Calendar.getInstance().timeInMillis))
+    fun toData(cloudData: Dictionary): TblHistory {
+        return TblHistory(cloudData.query, cloudData.word, Date(Calendar.getInstance().timeInMillis))
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/provider/DictionaryDataProvider.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/provider/DictionaryDataProvider.kt
@@ -23,7 +23,7 @@ class DictionaryDataProvider @Inject constructor(
             saveCloudData = { cloudData ->
                 val rowId = local.insertDictionary(mapper.toData(cloudData))
                 Timber.d("insert dictionary into db at $rowId")
-                historyProvider.insertHistory(query)
+                historyProvider.insertHistory(cloudData)
             })){ resource ->
                 mapper.toDomain(resource)
             }

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/provider/HistoryProvider.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/provider/HistoryProvider.kt
@@ -2,6 +2,7 @@ package com.example.foreverfreedictionary.domain.provider
 
 import androidx.lifecycle.LiveData
 import com.example.foreverfreedictionary.data.cloud.HistoryCloud
+import com.example.foreverfreedictionary.data.cloud.model.Dictionary
 import com.example.foreverfreedictionary.data.local.model.DictionaryHistory
 import com.example.foreverfreedictionary.data.local.room.HistoryDao
 import com.example.foreverfreedictionary.domain.mapper.HistoryMapper
@@ -23,7 +24,7 @@ class HistoryProvider @Inject constructor(
         })
     }
 
-    fun insertHistory(query: String){
-        local.insertHistory(historyMapper.toData(query))
+    fun insertHistory(cloudData: Dictionary){
+        local.insertHistory(historyMapper.toData(cloudData))
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/screen/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/screen/home/HomeFragment.kt
@@ -16,7 +16,7 @@ import com.example.foreverfreedictionary.di.injector
 import com.example.foreverfreedictionary.di.viewModel
 import com.example.foreverfreedictionary.ui.baseMVVM.BaseFragment
 import com.example.foreverfreedictionary.ui.screen.main.MainActivity
-import com.example.foreverfreedictionary.util.DICTIONARY_URL
+import com.example.foreverfreedictionary.util.SEARCH_FORM_SUBMIT_DIRECTION_URL
 import com.example.foreverfreedictionary.util.DOMAIN
 import com.example.foreverfreedictionary.vo.Status
 import kotlinx.android.synthetic.main.fragment_home.*
@@ -60,7 +60,7 @@ class HomeFragment : BaseFragment() {
                 request?.url?.let {
                     val stringUri = it.toString()
                     val query = when {
-                        stringUri.startsWith(DICTIONARY_URL) -> stringUri.substringAfterLast('/')
+                        stringUri.startsWith(SEARCH_FORM_SUBMIT_DIRECTION_URL) -> stringUri.substringAfterLast('/')
                         stringUri.startsWith(DOMAIN) -> stringUri.substringAfterLast(DOMAIN)
                         else -> ""
                     }

--- a/app/src/main/java/com/example/foreverfreedictionary/util/Constatns.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/util/Constatns.kt
@@ -2,5 +2,7 @@ package com.example.foreverfreedictionary.util
 
 const val DOMAIN = "https://www.ldoceonline.com/"
 const val DICTIONARY_URL = DOMAIN + "dictionary/"
+const val SEARCH_FORM_SUBMIT_DIRECTION_URL = DOMAIN + "search/english/direct/?q=/"
+const val CHECK_SPELL_URL = DOMAIN + "spellcheck/"
 const val LOCAL_DOMAIN = "file:///"
 const val LOCAL_DICTIONARY_URL = LOCAL_DOMAIN +"dictionary/"


### PR DESCRIPTION
- due to jsoup selections return null
- surround that block code by try-catch
- get redirected url returned from jsoup to determine which page was return.
- history table, dictionary table now use query as primary key instead of word.