### PR TITLE
[reminder feature]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.foreverfreedictionary">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="oppo.permission.OPPO_COMPONENT_SAFE"/>
+    <uses-permission android:name="com.huawei.permission.external_app_settings.USE_COMPONENT"/>
 
     <application
         android:name=".ui.ForeverFreeDictionaryApplication"
@@ -14,7 +18,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:ignore="GoogleAppIndexingWarning">
 
         <meta-data
             android:name="com.google.android.gms.version"
@@ -47,6 +52,11 @@
             android:parentActivityName=".ui.screen.main.MainActivity"/>
 
 
+        <receiver android:name=".ui.broadcastReceiver.ScheduleReminderBroadCastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <receiver android:name=".ui.broadcastReceiver.OnActionReminderNotificationBroadCastReceiver"
             android:process=":remote"
             android:enabled="true" />
@@ -54,8 +64,11 @@
             android:process=":remote" />
         <receiver android:name=".ui.broadcastReceiver.OnAlarmReminderBroadCastReceiver"
             android:process=":remote" />
-        <service android:name=".ui.service.ReminderService"
+        <service android:name=".ui.service.CheckingReminderService"
             android:exported="false"/>
+        <service android:name=".ui.service.ReminderJobService"
+            android:label="@string/menu_reminder"
+            android:permission="android.permission.BIND_JOB_SERVICE"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/foreverfreedictionary/data/local/room/ReminderDao.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/data/local/room/ReminderDao.kt
@@ -14,10 +14,10 @@ interface ReminderDao {
             "ORDER BY isReminded ASC, time DESC")
     fun getReminders() : LiveData<List<Reminder>>
 
-    @Query("SELECT * FROM reminder WHERE time <= :time")
+    @Query("SELECT * FROM reminder WHERE isReminded = 0 AND time <= :time")
     fun getRemindersInTime(time: Long) : LiveData<List<Reminder>>
 
-    @Query("SELECT count(*) FROM reminder WHERE time <= :time")
+    @Query("SELECT count(*) FROM reminder WHERE isReminded = 0 AND time <= :time")
     fun countRemindersInTime(time: Long) : Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/example/foreverfreedictionary/di/ServiceComponent.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/di/ServiceComponent.kt
@@ -2,7 +2,8 @@ package com.example.foreverfreedictionary.di
 
 import android.app.Application
 import com.example.foreverfreedictionary.di.module.*
-import com.example.foreverfreedictionary.ui.service.ReminderService
+import com.example.foreverfreedictionary.ui.service.CheckingReminderService
+import com.example.foreverfreedictionary.ui.service.ReminderJobService
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -18,5 +19,6 @@ interface ServiceComponent {
         fun build(): ServiceComponent
     }
 
-    fun inject(service: ReminderService)
+    fun inject(service: CheckingReminderService)
+    fun inject(service: ReminderJobService)
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/di/module/ServiceModule.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/di/module/ServiceModule.kt
@@ -1,6 +1,6 @@
 package com.example.foreverfreedictionary.di.module
 
-import com.example.foreverfreedictionary.ui.service.ReminderService
+import com.example.foreverfreedictionary.ui.service.CheckingReminderService
 import dagger.Module
 import dagger.Provides
 
@@ -9,7 +9,7 @@ import dagger.Provides
 @Module
 class ServiceModule {
     @Provides
-    fun provideReminderService(mService: ReminderService): ReminderService {
+    fun provideReminderService(mService: CheckingReminderService): CheckingReminderService {
         return mService
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/command/CountUnRemindedReminderCommand.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/command/CountUnRemindedReminderCommand.kt
@@ -4,13 +4,12 @@ import com.example.foreverfreedictionary.domain.provider.ReminderProvider
 import com.example.foreverfreedictionary.vo.Resource
 import javax.inject.Inject
 
-const val ONE_DAY = 1000L*60*60*24
 class CountUnRemindedReminderCommand @Inject constructor(
     private val provider: ReminderProvider
 ) {
 
     suspend fun execute(): Resource<Int>{
-        val time = System.currentTimeMillis() + ONE_DAY
+        val time = System.currentTimeMillis()
         return provider.countUnRemindedDictionaryReminder(time)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/domain/command/FetchRemindersInTimeCommand.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/domain/command/FetchRemindersInTimeCommand.kt
@@ -10,7 +10,7 @@ class FetchRemindersInTimeCommand @Inject constructor(
     private val provider: ReminderProvider
 ) : BaseLiveDataCommand<List<Reminder>>() {
     override suspend fun execute(): LiveData<Resource<List<Reminder>>> {
-        val time = System.currentTimeMillis() + ONE_DAY
+        val time = System.currentTimeMillis()
         return provider.getRemindersInTime(time)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/extensions/DateExtensions.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/extensions/DateExtensions.kt
@@ -34,10 +34,10 @@ fun Date.howLongTimeLapsedTilNow(): String{
 fun Date.howLongTilNext8Clock(): Long{
     val calendar = Calendar.getInstance()
     calendar.time = this
-    if (calendar.get(Calendar.HOUR) > 8){
+    if (calendar.get(Calendar.HOUR_OF_DAY) > 8){
         calendar.add(Calendar.DAY_OF_MONTH, 1)
     }
-    calendar.set(Calendar.HOUR, 8)
+    calendar.set(Calendar.HOUR_OF_DAY, 8)
     calendar.set(Calendar.MINUTE, 0)
     calendar.set(Calendar.SECOND, 0)
     calendar.set(Calendar.MILLISECOND, 0)
@@ -48,7 +48,7 @@ fun Date.getTomorrow0Clock(): Date{
     val calendar = Calendar.getInstance()
     calendar.time = this
     calendar.add(Calendar.DAY_OF_MONTH, 1)
-    calendar.set(Calendar.HOUR, 0)
+    calendar.set(Calendar.HOUR_OF_DAY, 0)
     calendar.set(Calendar.MINUTE, 0)
     calendar.set(Calendar.SECOND, 0)
     calendar.set(Calendar.MILLISECOND, 0)

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/OnAlarmReminderBroadCastReceiver.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/OnAlarmReminderBroadCastReceiver.kt
@@ -3,13 +3,13 @@ package com.example.foreverfreedictionary.ui.broadcastReceiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.example.foreverfreedictionary.ui.service.ReminderService
+import com.example.foreverfreedictionary.ui.service.CheckingReminderService
 import timber.log.Timber
 
 class OnAlarmReminderBroadCastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         Timber.d("OnAlarmReminderBroadCastReceiver")
-        val serviceIntent = Intent(context, ReminderService::class.java)
+        val serviceIntent = Intent(context, CheckingReminderService::class.java)
         context.startService(serviceIntent)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/OnShowRemindersNotificationBroadCastReceiver.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/OnShowRemindersNotificationBroadCastReceiver.kt
@@ -21,6 +21,9 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.StringBuilder
 import javax.inject.Inject
+import android.os.PowerManager
+
+
 
 /**
  * this class will try to fetch all eligible reminders from database, and show a notification
@@ -38,8 +41,7 @@ class OnShowRemindersNotificationBroadCastReceiver : BaseBroadCastReceiver() {
         Timber.d("OnShowRemindersNotificationBroadCastReceiver")
         val resultCode = intent.getIntExtra("resultCode", RESULT_CANCELED)
         if (resultCode == RESULT_OK) {
-//            fetchReminders(context)
-            showReminderNotification(context, "linh phan", listOf("clear"))
+            fetchReminders(context)
         }
     }
 
@@ -57,7 +59,7 @@ class OnShowRemindersNotificationBroadCastReceiver : BaseBroadCastReceiver() {
                     when(resource.status){
                         Status.LOADING -> {}
                         Status.ERROR -> {
-//                            liveData.removeObserver(this)
+                            liveData.removeObserver(this)
                         }
                         Status.SUCCESS -> {
                             resource.data?.let {reminders ->
@@ -89,5 +91,12 @@ class OnShowRemindersNotificationBroadCastReceiver : BaseBroadCastReceiver() {
             val builder = it.createReminderNotification(title, content, listQuery)
             it.mManager.notify(NotificationUtil.REMINDER_NOTIFICATION_ID, builder.build())
         }
+
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager?
+        val wakeLock = powerManager!!.newWakeLock(
+            PowerManager.FULL_WAKE_LOCK or PowerManager.ACQUIRE_CAUSES_WAKEUP,
+            OnShowRemindersNotificationBroadCastReceiver::class.java.name
+        )
+        wakeLock.acquire(3000)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/ScheduleReminderBroadCastReceiver.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/broadcastReceiver/ScheduleReminderBroadCastReceiver.kt
@@ -1,0 +1,15 @@
+package com.example.foreverfreedictionary.ui.broadcastReceiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.example.foreverfreedictionary.util.ReminderUtil
+import timber.log.Timber
+
+
+class ScheduleReminderBroadCastReceiver: BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        Timber.d("onReceive")
+        ReminderUtil.scheduleReminder(context)
+    }
+}

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/screen/main/MainActivity.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/screen/main/MainActivity.kt
@@ -42,12 +42,7 @@ import kotlin.coroutines.CoroutineContext
 import android.view.inputmethod.EditorInfo
 import androidx.core.view.postDelayed
 import com.example.foreverfreedictionary.ui.screen.ocr_text_recognizer.OcrCaptureActivity
-import android.app.AlarmManager
-import android.app.PendingIntent
-import com.example.foreverfreedictionary.extensions.howLongTilNext8Clock
-import com.example.foreverfreedictionary.ui.broadcastReceiver.OnAlarmReminderBroadCastReceiver
-import java.sql.Date
-
+import com.example.foreverfreedictionary.ui.broadcastReceiver.ScheduleReminderBroadCastReceiver
 
 const val REQUEST_CODE_RESULT_ACTIVITY = 11
 const val REQUEST_CODE_OCR_ACTIVITY = 12
@@ -79,9 +74,7 @@ class MainActivity : BaseActivity(), AutoCompletionViewHolder.OnItemListeners, C
         setupNavigator()
         registerViewModelListeners()
         registerEventListeners()
-        scheduleAlarm()
-//        val serviceIntent = Intent(this, ReminderService::class.java)
-//        startService(serviceIntent)
+        sendReminderBroadcast()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -153,24 +146,6 @@ class MainActivity : BaseActivity(), AutoCompletionViewHolder.OnItemListeners, C
             val intent = Intent(this, OcrCaptureActivity::class.java)
             startActivityForResult(intent, REQUEST_CODE_OCR_ACTIVITY)
         }
-    }
-
-    private fun scheduleAlarm() {
-        val intent = Intent(applicationContext, OnAlarmReminderBroadCastReceiver::class.java)
-        val alarmIntent = PendingIntent.getBroadcast(
-            applicationContext,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT
-        )
-        val startTime = Date(System.currentTimeMillis()).howLongTilNext8Clock()
-        val backupAlarmMgr = this.getSystemService(ALARM_SERVICE) as AlarmManager
-        backupAlarmMgr.setInexactRepeating(
-            AlarmManager.RTC_WAKEUP,
-            startTime,
-            AlarmManager.INTERVAL_DAY, //todo this must be changed to 1 hour
-            alarmIntent
-        )//alarm will repeat after every day
     }
 
 //    navigation section
@@ -339,5 +314,10 @@ class MainActivity : BaseActivity(), AutoCompletionViewHolder.OnItemListeners, C
         cslSearchBoxContainer.visibility = vs
         swDarkMode.visibility = vs
         hideAutoCompletion()
+    }
+
+    private fun sendReminderBroadcast(){
+        val scheduleBroadcastIntent = Intent(this, ScheduleReminderBroadCastReceiver::class.java)
+        sendBroadcast(scheduleBroadcastIntent)
     }
 }

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/service/CheckingReminderService.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/service/CheckingReminderService.kt
@@ -13,8 +13,8 @@ import com.example.foreverfreedictionary.ui.broadcastReceiver.OnShowRemindersNot
 import com.example.foreverfreedictionary.vo.Status
 
 
-class ReminderService @Inject constructor(
-) : IntentService(ReminderService::javaClass.name){
+class CheckingReminderService @Inject constructor(
+) : IntentService(CheckingReminderService::javaClass.name){
 
     companion object{
         const val ARG_REMINDERS_IN_TIME = "ARG_REMINDERS_IN_TIME"
@@ -36,21 +36,20 @@ class ReminderService @Inject constructor(
     }
 
     override fun onHandleIntent(intent: Intent?) {
-        Timber.d("ReminderService")
-        onHasRemindersInTime()
-//        intentServiceScope.launch {
-//            val resource = countUnRemindedReminderCommand.execute()
-//            when(resource.status){
-//                Status.LOADING -> {}
-//                Status.ERROR -> {}
-//                Status.SUCCESS ->{
-//                    val count = resource.data ?: 0
-//                    if(count > 0){
-//                        onHasRemindersInTime()
-//                    }
-//                }
-//            }
-//        }
+        Timber.d("CheckingReminderService")
+        intentServiceScope.launch {
+            val resource = countUnRemindedReminderCommand.execute()
+            when(resource.status){
+                Status.LOADING -> {}
+                Status.ERROR -> {}
+                Status.SUCCESS ->{
+                    val count = resource.data ?: 0
+                    if(count > 0){
+                        onHasRemindersInTime()
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/example/foreverfreedictionary/ui/service/ReminderJobService.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/ui/service/ReminderJobService.kt
@@ -1,0 +1,73 @@
+package com.example.foreverfreedictionary.ui.service
+
+import android.annotation.TargetApi
+import android.app.Activity
+import android.app.job.JobParameters
+import android.app.job.JobService
+import android.os.Build
+import android.content.Intent
+import com.example.foreverfreedictionary.di.DaggerServiceComponent
+import com.example.foreverfreedictionary.domain.command.CountUnRemindedReminderCommand
+import com.example.foreverfreedictionary.ui.broadcastReceiver.OnShowRemindersNotificationBroadCastReceiver
+import com.example.foreverfreedictionary.ui.mapper.ReminderMapper
+import com.example.foreverfreedictionary.util.ReminderUtil
+import com.example.foreverfreedictionary.vo.Status
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+class ReminderJobService: JobService() {
+    @Inject
+    lateinit var countUnRemindedReminderCommand: CountUnRemindedReminderCommand
+    @Inject
+    lateinit var reminderMapper: ReminderMapper
+    private val job: Job by lazy { Job() }
+    private val intentServiceScope: CoroutineScope by lazy { CoroutineScope(
+        Dispatchers.Default + job) }
+
+    override fun onCreate() {
+        DaggerServiceComponent.builder().application(application).build().inject(this)
+        super.onCreate()
+    }
+
+    override fun onStartJob(params: JobParameters?): Boolean {
+        Timber.d("onStartJob")
+        intentServiceScope.launch {
+            val resource = countUnRemindedReminderCommand.execute()
+            when(resource.status){
+                Status.LOADING -> {}
+                Status.ERROR -> {}
+                Status.SUCCESS ->{
+                    val count = resource.data ?: 0
+                    Timber.d("has $count in reminders")
+                    if(count > 0){
+                        onHasRemindersInTime()
+                        jobFinished(params, false)
+                    }
+                }
+            }
+        }
+
+        ReminderUtil.scheduleReminder(applicationContext) // reschedule the job
+        return true
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        Timber.d("onStopJob")
+        job.cancel()
+        return true
+    }
+
+
+
+    private fun onHasRemindersInTime() {
+        val intent = Intent(this, OnShowRemindersNotificationBroadCastReceiver::class.java)
+        intent.putExtra("resultCode", Activity.RESULT_OK)
+        sendBroadcast(intent)
+    }
+}

--- a/app/src/main/java/com/example/foreverfreedictionary/util/NotificationUtil.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/util/NotificationUtil.kt
@@ -39,7 +39,7 @@ class NotificationUtil(context: Context) : ContextWrapper(context) {
     private fun createChannels(){
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationChannel =
-                NotificationChannel(NOTIFICATION_CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT)
+                NotificationChannel(NOTIFICATION_CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
             //Boolean value to set if lights are enabled for Notifications from this Channel
             notificationChannel.enableLights(true)
             //Boolean value to set if vibration are enabled for Notifications from this Channel
@@ -70,7 +70,7 @@ class NotificationUtil(context: Context) : ContextWrapper(context) {
         builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM))
         builder.setVibrate(longArrayOf(500, 500, 500, 500))
         builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)//Lock Screen Visibility
-        builder.setLargeIcon(BitmapFactory.decodeResource(this.resources, R.drawable.round_alarm_black_36))
+        builder.setLargeIcon(BitmapFactory.decodeResource(this.resources, R.drawable.round_alarm_black_48))
 
         //This intent will be fired when the notification is tapped
         val intent = Intent(this, OnActionReminderNotificationBroadCastReceiver::class.java)
@@ -85,8 +85,8 @@ class NotificationUtil(context: Context) : ContextWrapper(context) {
 //        val buttonPendingIntent = PendingIntent.getBroadcast(this, 1002, buttonIntent, PendingIntent.FLAG_UPDATE_CURRENT)
 //        builder.addAction( R.drawable.ic_lock_idle_alarm, resources.getString(R.string.ok), buttonPendingIntent)
 
-//        builder.setStyle(NotificationCompat.BigTextStyle()
-//                .bigText(content))
+        builder.setStyle(NotificationCompat.BigTextStyle()
+                .bigText(content))
 
 //        builder.setStyle(NotificationCompat.BigPictureStyle()
 //            .bigPicture(BitmapFactory.decodeResource(application.resources, R.drawable.icon)))

--- a/app/src/main/java/com/example/foreverfreedictionary/util/PowerManagerUtil.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/util/PowerManagerUtil.kt
@@ -1,0 +1,115 @@
+package com.example.foreverfreedictionary.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+
+class PowerManagerUtil{
+
+    private fun openPowerManager(context: Context){
+        for (intent in POWERMANAGER_INTENTS)
+            if (context.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
+                // show dialog to ask user action
+                break
+            }
+
+        for (intent in POWERMANAGER_INTENTS)
+            if (context.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
+                context.startActivity(intent)
+                break
+            }
+    }
+
+    val POWERMANAGER_INTENTS = arrayOf(
+        Intent().setComponent(
+            ComponentName(
+                "com.miui.securitycenter",
+                "com.miui.permcenter.autostart.AutoStartManagementActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.letv.android.letvsafe",
+                "com.letv.android.letvsafe.AutobootManageActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.huawei.systemmanager",
+                "com.huawei.systemmanager.optimize.process.ProtectActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.huawei.systemmanager",
+                "com.huawei.systemmanager.appcontrol.activity.StartupAppControlActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.huawei.systemmanager",
+                "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.coloros.safecenter",
+                "com.coloros.safecenter.permission.startup.StartupAppListActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.coloros.safecenter",
+                "com.coloros.safecenter.startupapp.StartupAppListActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.oppo.safe",
+                "com.oppo.safe.permission.startup.StartupAppListActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.iqoo.secure",
+                "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.iqoo.secure",
+                "com.iqoo.secure.ui.phoneoptimize.BgStartUpManager"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.vivo.permissionmanager",
+                "com.vivo.permissionmanager.activity.BgStartUpManagerActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.samsung.android.lool",
+                "com.samsung.android.sm.ui.battery.BatteryActivity"
+            )
+        ), Intent().setComponent(
+            ComponentName(
+                "com.samsung.android.sm",
+                "com.samsung.android.sm.ui.battery.BatteryActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.htc.pitroad",
+                "com.htc.pitroad.landingpage.activity.LandingPageActivity"
+            )
+        ),
+        Intent().setComponent(
+            ComponentName(
+                "com.asus.mobilemanager",
+                "com.asus.mobilemanager.MainActivity"
+            )
+        )
+    )
+}

--- a/app/src/main/java/com/example/foreverfreedictionary/util/ReminderUtil.kt
+++ b/app/src/main/java/com/example/foreverfreedictionary/util/ReminderUtil.kt
@@ -1,0 +1,65 @@
+package com.example.foreverfreedictionary.util
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.app.job.JobScheduler
+import android.app.job.JobInfo
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.example.foreverfreedictionary.extensions.howLongTilNext8Clock
+import com.example.foreverfreedictionary.ui.broadcastReceiver.OnAlarmReminderBroadCastReceiver
+import com.example.foreverfreedictionary.ui.service.ReminderJobService
+import timber.log.Timber
+import java.sql.Date
+
+const val REMINDER_JOB_ID = 102
+object ReminderUtil {
+    fun scheduleReminder(context: Context){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            scheduleJob(context)
+        }else{
+            scheduleAlarm(context)
+        }
+    }
+
+    // schedule the start of the service every 10 - 30 seconds
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun scheduleJob(context: Context) {
+        val serviceComponent = ComponentName(context, ReminderJobService::class.java)
+        val builder = JobInfo.Builder(REMINDER_JOB_ID, serviceComponent)
+        val timeToStart = Date(System.currentTimeMillis()).howLongTilNext8Clock()
+        Timber.d("job is set in $timeToStart")
+        builder.setMinimumLatency(timeToStart) // wait at least
+        builder.setOverrideDeadline(timeToStart + 60000) // maximum delay
+        //builder.setRequiredNetworkType(JobInfo.NETWORK_TYPE_UNMETERED); // require unmetered network
+//        builder.setRequiresDeviceIdle(true) // device should be idle
+        //builder.setRequiresCharging(false); // we don't care if the device is charging or not
+        builder.setPersisted(true)
+        val jobScheduler = ContextCompat.getSystemService(context, JobScheduler::class.java)
+        jobScheduler?.schedule(builder.build())
+    }
+
+    private fun scheduleAlarm(context: Context) {
+        val applicationContext = context.applicationContext
+        val intent = Intent(applicationContext, OnAlarmReminderBroadCastReceiver::class.java)
+        val alarmIntent = PendingIntent.getBroadcast(
+            applicationContext,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val startTime = Date(System.currentTimeMillis()).howLongTilNext8Clock()
+        val backupAlarmMgr = context.getSystemService(AppCompatActivity.ALARM_SERVICE) as AlarmManager
+        backupAlarmMgr.setInexactRepeating(
+            AlarmManager.RTC_WAKEUP,
+            startTime,
+            AlarmManager.INTERVAL_DAY,
+            alarmIntent
+        )//alarm will repeat after every day
+    }
+}


### PR DESCRIPTION
- problem: due to alarm can't get called on recent android versions
- resolve: as google recommends we use JobSchedule for schedule background job instead. there are some cases it may not work due to manufacture's stock rooms which manage battery time usage. in this such a case we should prompt user an alert later on.